### PR TITLE
Added sync_userid & sync_groupid permissions

### DIFF
--- a/.docker/redis/Dockerfile
+++ b/.docker/redis/Dockerfile
@@ -10,5 +10,6 @@ RUN apk update && apk upgrade --available
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC  /etc/localtime \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone \
+    && chown redis:redis -R /data \
     && apk del tzdata \
     && rm -rf /var/cache/apk/*

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -6,6 +6,8 @@ syncs:
   app_data:
     src: ${PWD}/htdocs
     sync_strategy: 'native_osx'
+    sync_userid: 1000
+    sync_groupid: 1000
     sync_args:
     - "-prefer newer"
     - "-ignore='Path .git'"


### PR DESCRIPTION
Fixes this issue: https://github.com/aliuosio/mage2.docker/issues/9

Added the right owner for Redis to write to file. Fixes this error in the redis container: MISCONF Redis is configured to save RDB snapshots.

